### PR TITLE
Map Format Changes for Balance()

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,13 @@ const balance = ({ reactants, products }) => {
   const reduced = rref(getCompositionMatrix(compounds, reactants.length));
   const wholeCoeffs = scaleFractions(coefficients(reduced));
 
-  return new Map(compounds.map((compound, i) => [compound, wholeCoeffs[i]]));
+  return new Map(compounds.map((compound, i) => [
+    compound,
+    {
+      coefficient: wholeCoeffs[i], //adds a reactant and product type to the output, for simple referencing of the map. This is based off of the input. 
+      type: i < reactants.length ? "reactant" : "product",
+    },
+  ]));
 };
 
 const coefficients = (reducedMatrix) => {


### PR DESCRIPTION
Adds a reactant and product type to the output, for simple referencing of the map. This is based off of the input. 

I.E.

 Map(4) {
  'C6H12O6' => { coefficient: 1, type: 'reactant' },
  'O2' => { coefficient: 6, type: 'reactant' },
  'CO2' => { coefficient: 6, type: 'product' },
  'H2O' => { coefficient: 6, type: 'product' }
}
Allows for simple reassembly as per requirement.